### PR TITLE
chore: remove personal bot name from mentionPatterns example

### DIFF
--- a/docs/openclaw-config.md
+++ b/docs/openclaw-config.md
@@ -58,7 +58,7 @@ Resilience for transient network errors (outbound `sendMessage`, `editMessage`, 
 ### Mention Patterns
 Added to `agents.list[].groupChat.mentionPatterns` for fallback detection:
 ```json
-"mentionPatterns": ["@your_bot_username", "clawdy", "bot"]
+"mentionPatterns": ["@your_bot_username", "bot"]
 ```
 These are case-insensitive regexes. Native Telegram @-mentions still work; patterns are a safety net.
 


### PR DESCRIPTION
Sanitization pass — clawdy is a personal bot name that shouldn't appear in the public template. Replaced with just  and  as generic examples.