### PR TITLE
chore: align openclaw.example.json with docs/openclaw-config.md

### DIFF
--- a/openclaw.example.json
+++ b/openclaw.example.json
@@ -21,6 +21,9 @@
     "telegram": {
       "enabled": true,
       "dmPolicy": "pairing",
+      "allowFrom": [
+        "<your-telegram-user-id>"
+      ],
       "groupPolicy": "allowlist",
       "groupAllowFrom": [
         "<your-telegram-user-id>"
@@ -35,6 +38,11 @@
       "groups": {
         "*": {
           "requireMention": true
+        },
+        "<your-group-chat-id>": {
+          "requireMention": false,
+          "groupPolicy": "open",
+          "systemPrompt": "You're in a group chat..."
         }
       }
     }
@@ -92,7 +100,8 @@
         "default": true,
         "groupChat": {
           "mentionPatterns": [
-            "@your_bot_username"
+            "@your_bot_username",
+            "bot"
           ]
         }
       }


### PR DESCRIPTION
Three changes to match the config doc:

- **DM `allowFrom`** — doc describes this as an extra access layer beyond pairing; added to example
- **Specific group example** — doc shows a group with `requireMention: false`, `groupPolicy: "open"`, and a `systemPrompt`; added placeholder to example
- **`mentionPatterns`** — doc shows `["@your_bot_username", "bot"]`; example was missing `"bot"`

JSON validated. No breaking changes — all additions are placeholder values.