### PR TITLE
fix(renovate): suppress false go detection and track Hugo version in pages.yml

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -33,6 +33,16 @@
       ]
     },
     {
+      "description": "Suppress false go detection in pages.yml (HUGO_VERSION misidentified as go)",
+      "matchFileNames": [
+        ".github/workflows/pages.yml"
+      ],
+      "matchPackageNames": [
+        "go"
+      ],
+      "enabled": false
+    },
+    {
       "description": "Group Docker base image updates for manual review",
       "matchManagers": [
         "dockerfile",
@@ -129,6 +139,19 @@
         "ARG SOPS_VERSION=(?<currentValue>[\\d]+\\.[\\d]+(?:\\.[\\d]+)?)"
       ],
       "depNameTemplate": "getsops/sops",
+      "datasourceTemplate": "github-releases",
+      "extractVersionTemplate": "^v(?<version>.+)$"
+    },
+    {
+      "description": "Track Hugo version pinned as env var in pages.yml",
+      "customType": "regex",
+      "managerFilePatterns": [
+        "/^\\.github/workflows/pages\\.yml$/"
+      ],
+      "matchStrings": [
+        "HUGO_VERSION: (?<currentValue>[\\d]+\\.[\\d]+\\.[\\d]+)"
+      ],
+      "depNameTemplate": "gohugoio/hugo",
       "datasourceTemplate": "github-releases",
       "extractVersionTemplate": "^v(?<version>.+)$"
     },


### PR DESCRIPTION
## Summary

Fixes the bogus PR #14 which changed `HUGO_VERSION: 0.158.0` → `1.26.1` (a Go version).

- Adds a `packageRules` entry disabling `go` package detection in `pages.yml` (suppresses the false positive)
- Adds a custom regex manager that correctly tracks `HUGO_VERSION` against `gohugoio/hugo` GitHub releases

## Root cause

Renovate's built-in GitHub Actions manager detects `go-version: ${{ env.GO_VERSION }}` in the `setup-go` step and scans the surrounding env block, misidentifying `HUGO_VERSION: 0.158.0` as a `go` package at version `0.158.0`, then "updating" it to the latest Go release.

## Test plan

- [ ] Close/reject PR #14
- [ ] Trigger a Renovate dry-run and confirm `HUGO_VERSION` now appears under `gohugoio/hugo` (not `go`), and no false `go` update PR is generated for `pages.yml`

🤖 Generated with [Claude Code](https://claude.com/claude-code)