### PR TITLE
chore: bump OpenClaw to 2026.7.1 (resolves lossless-claw load failure)

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -47,7 +47,7 @@ RUN curl -LsSf https://astral.sh/uv/${UV_VERSION}/install.sh | sh \
   && rm -rf /root/.local
 
 # Pin versions for reproducible builds — bump explicitly when upgrading
-ARG OPENCLAW_VERSION=2026.5.7
+ARG OPENCLAW_VERSION=2026.7.1
 ARG CLAWHUB_VERSION=0.9.0
 ARG SUMMARIZE_VERSION=0.14.1
 ARG WS_VERSION=8.20.0

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -56,7 +56,7 @@ fi
 ###############################################################################
 if [[ "${INSTALL_LOSSLESS_CLAW:-1}" != "0" ]]; then
   echo "[entrypoint] Installing lossless-claw plugin ..."
-  openclaw plugins install @martian-engineering/lossless-claw@0.9.4 2>&1 || {
+  openclaw plugins install @martian-engineering/lossless-claw@0.15.1 2>&1 || {
     echo "[entrypoint] WARNING: Failed to install lossless-claw — continuing"
   }
 else


### PR DESCRIPTION
## Summary
Bumps the pinned OpenClaw version from `2026.5.7` → `2026.7.1` (latest stable) and lossless-claw from `0.9.4` → `0.15.1`.

## Why
- OpenClaw `2026.7.1` is the current latest release; local instance reports upgrade available since v2026.7.1-2.
- `lossless-claw@0.9.4` currently fails to load at runtime with `ERR_MODULE_NOT_FOUND: Cannot find package '@mariozechner/pi-coding-agent'` and silently falls back to the legacy context engine on every session. Versions `≥0.13` dropped the `@mariozechner/pi-*`/ peer deps and only require `openclaw >=2026.5.28`, which `2026.7.1` satisfies.

## Verification (done on the VPS)
- `openclaw config validate` against `2026.7.1` reports the config **valid** (only plugin-install warnings for dropbox/chutes/acpx, no schema errors).
- `lossless-claw@0.15.1` installs cleanly under 2026.7.1 — plugin warning disappears.
- Node 24 base image (`node:24-bookworm-slim` @ v24.18.1) satisfies engine `>=24.15.0 <25`.
- CI docker-build check will build this image.

Supersedes stale renovate PR #119 (`2026.6.33`).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the bundled OpenClaw version.
  * Updated the lossless-claw plugin to the latest supported version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->