### PR TITLE
feat: validate openclaw config against pinned schema in CI, update example config

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -25,6 +25,35 @@ jobs:
       - name: Run make validate
         run: make validate
 
+  openclaw-config:
+    name: OpenClaw config schema
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v7
+
+      - name: Validate configs against pinned OpenClaw schema
+        run: |
+          VER=$(grep -oP 'ARG OPENCLAW_VERSION=\K[^ ]+' docker/Dockerfile)
+          if [[ -z "$VER" ]]; then
+            echo "ERROR: could not read OPENCLAW_VERSION from docker/Dockerfile" >&2
+            exit 1
+          fi
+          for cfg in openclaw.json openclaw.example.json; do
+            if [[ ! -f "$cfg" ]]; then
+              echo "SKIP: $cfg not present in this repo"
+              continue
+            fi
+            echo "Validating $cfg against openclaw@${VER} schema..."
+            if ! OPENCLAW_CONFIG_PATH="$GITHUB_WORKSPACE/$cfg" npx -y "openclaw@${VER}" config validate --json \
+                 | jq -e '.valid == true' > /dev/null; then
+              echo "ERROR: $cfg is invalid against openclaw@${VER} schema" >&2
+              OPENCLAW_CONFIG_PATH="$GITHUB_WORKSPACE/$cfg" npx -y "openclaw@${VER}" config validate --json >&2 || true
+              exit 1
+            fi
+            echo "✓ $cfg validates against openclaw@${VER}"
+          done
+
   terraform-test:
     name: Terraform Lint & Test
     runs-on: ubuntu-latest

--- a/openclaw.example.json
+++ b/openclaw.example.json
@@ -38,7 +38,13 @@
       "groupAllowFrom": [
         "<your-telegram-user-id>"
       ],
-      "streaming": "partial",
+      "streaming": {
+        "mode": "progress",
+        "progress": {
+          "toolProgress": true,
+          "commandText": "status"
+        }
+      },
       "retry": {
         "attempts": 3,
         "minDelayMs": 400,
@@ -68,6 +74,15 @@
           "freshTailCount": 32,
           "contextThreshold": 0.75,
           "incrementalMaxDepth": -1
+        }
+      },
+      "memory-core": {
+        "enabled": true,
+        "config": {
+          "dreaming": {
+            "enabled": true,
+            "timezone": "UTC"
+          }
         }
       },
       "diffs": {


### PR DESCRIPTION
- Add openclaw-config job to validate.yml: validates openclaw.json and
  openclaw.example.json with 'openclaw config validate' against the exact
  OpenClaw version pinned in docker/Dockerfile (gates PRs on schema drift)
- Fix openclaw.example.json: migrate legacy 'streaming: partial' string form
  to the current object schema ('progress' mode with tool progress + status
  command text)
- Add memory-core dreaming entry to openclaw.example.json (enabled, UTC)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enabled memory functionality with UTC-based dreaming in the example configuration.
  - Added tool-progress reporting for Telegram streaming responses.

- **Improvements**
  - Updated Telegram status command text to use the clearer `"status"` label.
  - Added automated validation for OpenClaw configuration files, with diagnostics for invalid settings and graceful handling of missing files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->