### PR TITLE
fix(install-sops): support sops 3.13+ sigstore bundle verification

### DIFF
--- a/ansible/plays/config.yml
+++ b/ansible/plays/config.yml
@@ -187,7 +187,7 @@
 
     - name: Install cosign on VPS
       ansible.builtin.shell: |
-        COSIGN_VERSION=3.1.3
+        COSIGN_VERSION=2.6.5
         mkdir -p ~/.local/bin
         curl -fsSL "https://github.com/sigstore/cosign/releases/download/v${COSIGN_VERSION}/cosign-linux-amd64" \
           -o ~/.local/bin/cosign

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -35,7 +35,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 # Install SOPS (for native secrets decryption via exec provider)
 # cosign is used at build time to verify the SOPS release signature — no hardcoded hash needed.
 ARG SOPS_VERSION=3.12.2
-COPY --from=gcr.io/projectsigstore/cosign:v3.1.3 /ko-app/cosign /usr/local/bin/cosign
+COPY --from=gcr.io/projectsigstore/cosign:v2.6.5 /ko-app/cosign /usr/local/bin/cosign
 COPY scripts/install-sops.sh /usr/local/bin/install-sops.sh
 RUN bash /usr/local/bin/install-sops.sh "${SOPS_VERSION}"
 

--- a/scripts/install-sops.sh
+++ b/scripts/install-sops.sh
@@ -17,10 +17,10 @@ SOPS_ASSET="sops-v${SOPS_VERSION}.linux.amd64"
 tmpdir=$(mktemp -d)
 trap 'rm -rf "$tmpdir"' EXIT
 
-curl -fsSL "${SOPS_BASE}/${SOPS_ASSET}"              -o "${tmpdir}/sops"
-curl -fsSL "${SOPS_BASE}/sops-v${SOPS_VERSION}.checksums.txt" -o "${tmpdir}/checksums.txt"
+curl -fsSL --proto =https "${SOPS_BASE}/${SOPS_ASSET}"              -o "${tmpdir}/sops"
+curl -fsSL --proto =https "${SOPS_BASE}/sops-v${SOPS_VERSION}.checksums.txt" -o "${tmpdir}/checksums.txt"
 
-if curl -fsSL "${SOPS_BASE}/sops-v${SOPS_VERSION}.checksums.sigstore.json" -o "${tmpdir}/bundle.json" 2>/dev/null; then
+if curl -fsSL --proto =https "${SOPS_BASE}/sops-v${SOPS_VERSION}.checksums.sigstore.json" -o "${tmpdir}/bundle.json" 2>/dev/null; then
   # sops >= 3.13 publishes a cosign bundle instead of the classic
   # .sig/.pem pair. cosign v3.1.x cannot verify this bundle directly
   # ("bundle does not contain cert" / "unsupported tlog public key type:
@@ -43,8 +43,8 @@ EOF
     "${tmpdir}/checksums.txt"
 else
   # sops <= 3.12: classic cosign certificate + signature assets
-  curl -fsSL "${SOPS_BASE}/sops-v${SOPS_VERSION}.checksums.sig" -o "${tmpdir}/checksums.sig"
-  curl -fsSL "${SOPS_BASE}/sops-v${SOPS_VERSION}.checksums.pem" -o "${tmpdir}/checksums.pem"
+  curl -fsSL --proto =https "${SOPS_BASE}/sops-v${SOPS_VERSION}.checksums.sig" -o "${tmpdir}/checksums.sig"
+  curl -fsSL --proto =https "${SOPS_BASE}/sops-v${SOPS_VERSION}.checksums.pem" -o "${tmpdir}/checksums.pem"
   cosign verify-blob \
     --certificate "${tmpdir}/checksums.pem" \
     --signature   "${tmpdir}/checksums.sig" \

--- a/scripts/install-sops.sh
+++ b/scripts/install-sops.sh
@@ -22,22 +22,11 @@ curl -fsSL --proto =https "${SOPS_BASE}/sops-v${SOPS_VERSION}.checksums.txt" -o 
 
 if curl -fsSL --proto =https "${SOPS_BASE}/sops-v${SOPS_VERSION}.checksums.sigstore.json" -o "${tmpdir}/bundle.json" 2>/dev/null; then
   # sops >= 3.13 publishes a cosign bundle instead of the classic
-  # .sig/.pem pair. cosign v3.1.x cannot verify this bundle directly
-  # ("bundle does not contain cert" / "unsupported tlog public key type:
-  # PKIX_ED25519"), so extract the certificate + signature from the bundle
-  # and verify with the classic flags.
-  python3 - "${tmpdir}/bundle.json" "${tmpdir}/cert.pem" "${tmpdir}/signature.b64" <<'EOF'
-import base64, json, sys
-bundle = json.load(open(sys.argv[1]))
-cert = bundle["verificationMaterial"]["certificate"]["rawBytes"]
-sig = bundle["messageSignature"]["signature"]
-pem = b"-----BEGIN CERTIFICATE-----\n" + base64.b64encode(base64.b64decode(cert)) + b"\n-----END CERTIFICATE-----\n"
-open(sys.argv[2], "wb").write(pem)
-open(sys.argv[3], "w").write(sig)
-EOF
+  # .sig/.pem pair. Requires cosign >= 2.6 — cosign v3.1.x cannot verify
+  # this bundle ("bundle does not contain cert" / "unsupported tlog public
+  # key type: PKIX_ED25519").
   cosign verify-blob \
-    --certificate   "${tmpdir}/cert.pem" \
-    --signature     "$(cat "${tmpdir}/signature.b64")" \
+    --bundle "${tmpdir}/bundle.json" \
     --certificate-identity "https://github.com/getsops/sops/.github/workflows/release.yml@refs/tags/v${SOPS_VERSION}" \
     --certificate-oidc-issuer "https://token.actions.githubusercontent.com" \
     "${tmpdir}/checksums.txt"

--- a/scripts/install-sops.sh
+++ b/scripts/install-sops.sh
@@ -19,15 +19,39 @@ trap 'rm -rf "$tmpdir"' EXIT
 
 curl -fsSL "${SOPS_BASE}/${SOPS_ASSET}"              -o "${tmpdir}/sops"
 curl -fsSL "${SOPS_BASE}/sops-v${SOPS_VERSION}.checksums.txt" -o "${tmpdir}/checksums.txt"
-curl -fsSL "${SOPS_BASE}/sops-v${SOPS_VERSION}.checksums.sig" -o "${tmpdir}/checksums.sig"
-curl -fsSL "${SOPS_BASE}/sops-v${SOPS_VERSION}.checksums.pem" -o "${tmpdir}/checksums.pem"
 
-cosign verify-blob \
-  --certificate "${tmpdir}/checksums.pem" \
-  --signature   "${tmpdir}/checksums.sig" \
-  --certificate-identity "https://github.com/getsops/sops/.github/workflows/release.yml@refs/tags/v${SOPS_VERSION}" \
-  --certificate-oidc-issuer "https://token.actions.githubusercontent.com" \
-  "${tmpdir}/checksums.txt"
+if curl -fsSL "${SOPS_BASE}/sops-v${SOPS_VERSION}.checksums.sigstore.json" -o "${tmpdir}/bundle.json" 2>/dev/null; then
+  # sops >= 3.13 publishes a cosign bundle instead of the classic
+  # .sig/.pem pair. cosign v3.1.x cannot verify this bundle directly
+  # ("bundle does not contain cert" / "unsupported tlog public key type:
+  # PKIX_ED25519"), so extract the certificate + signature from the bundle
+  # and verify with the classic flags.
+  python3 - "${tmpdir}/bundle.json" "${tmpdir}/cert.pem" "${tmpdir}/signature.b64" <<'EOF'
+import base64, json, sys
+bundle = json.load(open(sys.argv[1]))
+cert = bundle["verificationMaterial"]["certificate"]["rawBytes"]
+sig = bundle["messageSignature"]["signature"]
+pem = b"-----BEGIN CERTIFICATE-----\n" + base64.b64encode(base64.b64decode(cert)) + b"\n-----END CERTIFICATE-----\n"
+open(sys.argv[2], "wb").write(pem)
+open(sys.argv[3], "w").write(sig)
+EOF
+  cosign verify-blob \
+    --certificate   "${tmpdir}/cert.pem" \
+    --signature     "$(cat "${tmpdir}/signature.b64")" \
+    --certificate-identity "https://github.com/getsops/sops/.github/workflows/release.yml@refs/tags/v${SOPS_VERSION}" \
+    --certificate-oidc-issuer "https://token.actions.githubusercontent.com" \
+    "${tmpdir}/checksums.txt"
+else
+  # sops <= 3.12: classic cosign certificate + signature assets
+  curl -fsSL "${SOPS_BASE}/sops-v${SOPS_VERSION}.checksums.sig" -o "${tmpdir}/checksums.sig"
+  curl -fsSL "${SOPS_BASE}/sops-v${SOPS_VERSION}.checksums.pem" -o "${tmpdir}/checksums.pem"
+  cosign verify-blob \
+    --certificate "${tmpdir}/checksums.pem" \
+    --signature   "${tmpdir}/checksums.sig" \
+    --certificate-identity "https://github.com/getsops/sops/.github/workflows/release.yml@refs/tags/v${SOPS_VERSION}" \
+    --certificate-oidc-issuer "https://token.actions.githubusercontent.com" \
+    "${tmpdir}/checksums.txt"
+fi
 
 expected=$(grep "${SOPS_ASSET}$" "${tmpdir}/checksums.txt" | awk '{print $1}')
 echo "${expected}  ${tmpdir}/sops" | sha256sum --check


### PR DESCRIPTION
sops 3.13.x replaced the cosign .sig/.pem release assets with a single
checksums.sigstore.json bundle, breaking install-sops.sh (curl 404 →
build failure). cosign v3.1.x cannot verify the bundle directly
('bundle does not contain cert' / 'unsupported tlog public key type:
PKIX_ED25519'), so extract the certificate and signature from the bundle
and verify with the classic flags. Falls back to the legacy .sig/.pem
flow for sops <= 3.12.

Verified end-to-end on GNU/Linux for both 3.13.3 (new path) and 3.12.2
(legacy path).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved SOPS integrity verification across newer and older releases.
  * Added support for Sigstore bundle-based verification while retaining compatibility with classic certificate and signature formats.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->