### PR TITLE
fix: bump clawhub CLI to 0.23.3 (consistent installedAt timestamps)

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -48,7 +48,7 @@ RUN curl -LsSf https://astral.sh/uv/${UV_VERSION}/install.sh | sh \
 
 # Pin versions for reproducible builds — bump explicitly when upgrading
 ARG OPENCLAW_VERSION=2026.7.1
-ARG CLAWHUB_VERSION=0.9.0
+ARG CLAWHUB_VERSION=0.23.3
 ARG SUMMARIZE_VERSION=0.21.9
 ARG WS_VERSION=8.20.0
 ARG AGENT_BROWSER_VERSION=0.22.3


### PR DESCRIPTION
Fixes ClawHub skill 'link invalid' errors in the OpenClaw dashboard.

**Root cause** (clawhub/clawhub#2559): `clawhub install`/update wrote `Date.now()` separately for `.clawhub/origin.json` and the workspace lockfile (1-3ms drift). OpenClaw's status check compares with strict `!==` → every entrypoint-installed skill flagged as 'origin metadata does not match the workspace ClawHub lockfile'.

**Fix**: 0.23.3 includes commit 8970a46 ("use consistent installedAt timestamp for origin.json and lockfile", merged via #2569).

**After merge**: sync to openclaw-prod, delete broken skill dirs + lockfile on VPS once, `make deploy REBUILD=1` — entrypoint reinstalls all manifest skills with matching timestamps.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the packaged Clawhub version to 0.23.3 for Docker builds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->