### PR TITLE
fix: use openclaw skills install in entrypoint

### DIFF
--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -35,14 +35,15 @@ if [[ -f "$MANIFEST" ]]; then
     line="$(echo "$line" | xargs)"
     [[ -z "$line" ]] && continue
 
-    # Skip if already installed
-    if [[ -d "$WORKDIR/skills/$line" ]]; then
+    # Skip if already installed (manifest refs are @owner/slug; install dir is the bare slug)
+    slug="${line##*/}"
+    if [[ -d "$WORKDIR/skills/$slug" ]]; then
       echo "[entrypoint]   ✓ $line (already installed)"
       continue
     fi
 
     echo "[entrypoint]   → installing $line"
-    clawhub install "$line" --workdir "$WORKDIR" --force || {
+    openclaw skills install "$line" --force --acknowledge-clawhub-risk || {
       echo "[entrypoint] WARNING: Failed to install $line — continuing"
     }
   done < "$MANIFEST"


### PR DESCRIPTION
**Problem:** `clawhub install @owner/slug` (0.23.3) nests installs at `skills/@owner/slug` and writes `@owner/slug`-prefixed lockfile keys. OpenClaw's skill status check looks up bare slugs → every skill flagged 'origin metadata does not match the workspace ClawHub lockfile' in the dashboard.

**Fix:** entrypoint now uses `openclaw skills install @owner/slug --force --acknowledge-clawhub-risk`:
- installs flat at `skills/<slug>`
- writes bare-slug lockfile keys with full provenance (ownerHandle, artifact sha256, skillFile hash) — matches `resolveClawHubSkillStatusLinkSync`
- skip-check uses the bare slug part of the manifest ref
- `--acknowledge-clawhub-risk` keeps non-interactive install working for skills with security-scan warnings (e.g. yt)

**Verified on VPS:** openclaw install → `skills/yt/` + lockfile key `yt`; clawhub install → `skills/@therohitdas/yt/` + key `@therohitdas/yt`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved skill installation checks for manifest references that include an owner prefix.
  * Updated installation behavior to automatically acknowledge installation risks and use the current workspace.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->